### PR TITLE
Add activity feed API

### DIFF
--- a/graphite-demo/server.js
+++ b/graphite-demo/server.js
@@ -1,0 +1,30 @@
+const express = require('express');
+const app = express();
+const port = 3000;
+
+// Fake data for the activity feed
+const activityFeed = [
+  {
+    id: 1000,
+    title: 'New Photo Uploaded',
+    body: 'Alice uploaded a new photo to her album.'
+  },
+  {
+    id: 2000,
+    title: 'Comment on Post',
+    body: "Bob commented on Charlie's post."
+  },
+  {
+    id: 13,
+    title: 'Status Update',
+    body: 'Charlie updated their status: "Excited about the new project!"'
+  }
+];
+
+app.get('/feed', (req, res) => {
+  res.json(activityFeed);
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});

--- a/modules/home/apps/popsicle.nix
+++ b/modules/home/apps/popsicle.nix
@@ -1,0 +1,5 @@
+{ pkgs, ... }:
+{
+  # burn drives
+  home.packages = [ pkgs.popsicle ];
+}

--- a/modules/home/terminal/utils.nix
+++ b/modules/home/terminal/utils.nix
@@ -22,7 +22,8 @@
     wget # download files, over curl
     bat # cat alternative
     yt-dlp # download videos
-    popsicle # burn drives
+    xxh # transfer shell config over ssh
+    sshpass # needed for xxh
 
     jq
     # zathura imv # pdf/image viewer


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a demo server that serves an activity feed at GET /feed and runs on port 3000.
- Chores
  - Introduced a home configuration module to include the Popsicle application in your environment.
  - Updated terminal utilities: added xxh and sshpass for improved SSH workflows; removed Popsicle from this utilities list (now managed via the dedicated module).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->